### PR TITLE
Stateless comblock

### DIFF
--- a/src/comblock.c
+++ b/src/comblock.c
@@ -72,7 +72,7 @@ static uint8_t **comBlockGetZstd(FCHandle fc, const int index) {
     if (!comBlockLookupTable(fc, index, &cbAddr, &cbSize))
         fatalf(E_APP, "error looking up compression block: %d\n", index);
 
-    assert(cbAddr >= 32);
+    assert(cbAddr >= curSequence.channelDataOffset);
     assert(cbSize > 0);
 
     const size_t dInSize = cbSize;

--- a/src/comblock.c
+++ b/src/comblock.c
@@ -68,9 +68,12 @@ static bool comBlockLookupTable(FCHandle fc,
 
 static uint8_t **comBlockGetZstd(FCHandle fc, const int index) {
     // attempt to read the address and size of the compression block
-    uint32_t cbAddr, cbSize;
+    uint32_t cbAddr = 0, cbSize = 0;
     if (!comBlockLookupTable(fc, index, &cbAddr, &cbSize))
         fatalf(E_APP, "error looking up compression block: %d\n", index);
+
+    assert(cbAddr > 32);
+    assert(cbSize > 0);
 
     const size_t dInSize = cbSize;
     void *dIn = mustMalloc(dInSize);

--- a/src/comblock.c
+++ b/src/comblock.c
@@ -72,7 +72,7 @@ static uint8_t **comBlockGetZstd(FCHandle fc, const int index) {
     if (!comBlockLookupTable(fc, index, &cbAddr, &cbSize))
         fatalf(E_APP, "error looking up compression block: %d\n", index);
 
-    assert(cbAddr > 32);
+    assert(cbAddr >= 32);
     assert(cbSize > 0);
 
     const size_t dInSize = cbSize;

--- a/src/comblock.h
+++ b/src/comblock.h
@@ -5,10 +5,6 @@
 
 #include "std/fc.h"
 
-void comBlocksInit(FCHandle fc);
-
 uint8_t **comBlockGet(FCHandle fc, int index);
-
-void comBlocksFree(void);
 
 #endif//FPLAYER_COMBLOCK_H

--- a/src/player.c
+++ b/src/player.c
@@ -206,8 +206,6 @@ void playerRun(FCHandle fc,
                const PlayerOpts opts) {
     Seq_initHeader(fc);
 
-    comBlocksInit(fc);
-
     if (opts.precomputeFades) {
         char *const cacheFilePath = dsprintf("%s.pcf", FC_filepath(fc));
 
@@ -231,7 +229,6 @@ void playerRun(FCHandle fc,
 
     // playback finished, free resources and exit cleanly
     precomputeFree();
-    comBlocksFree();
 
     framePumpFree(&gFramePump);
 


### PR DESCRIPTION
Replaces the global and manually managed `gBlocks` (compression block array) that backed the `comblock.h` functions. When reading an arbitrary compression block index, it will now compute the absolute file address using the compression block table. This draws off some extra compute for less memory usage and also removing all memory management. 